### PR TITLE
fix(llvm): Lack of -l flag for additional libraries in llvm style linker

### DIFF
--- a/GCCBuild/Nuget/build/Microsoft.Cpp.props
+++ b/GCCBuild/Nuget/build/Microsoft.Cpp.props
@@ -289,7 +289,7 @@
     </GCCToolLinker_Flags>
     <GCCToolLinker_Flags Include="AdditionalDeps">
       <MappingVariable>AdditionalDependencies</MappingVariable>
-      <Flag>@{;}</Flag>
+      <Flag>-l@{;}</Flag>
       <Flag_WSLAware>true</Flag_WSLAware>
     </GCCToolLinker_Flags>
     <GCCToolLinker_Flags Include="ConfigurationType">


### PR DESCRIPTION
@roozbehid  I have found also small problem with additional libraries flag when linking with LLVM style.
This pull request should solve this problem.
Could you please tell me if there is any planned date for updating package on nuget.org?